### PR TITLE
Add warnings for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: node_js
+matrix:
+  allow_failures:
+    - node_js: "0.12"
 node_js:
   - "0.10"
   - "0.12"

--- a/README.md
+++ b/README.md
@@ -36,17 +36,27 @@ been changed which may bleed in to how components are implemented.
 `React.createClass` automatically binds all non-static methods to the component
 instance so that you do not need to automatically bind them. This is typically 
 used when registering event handlers or passing methods between components. If
-your component does this, you will need to manually bind the method.
+your component relies on this, it's not as simple as just using bind because 
+React on the client will warn about binding methods that are already autobound.
+Instead, you can create a closure:
 
 ```
-<a onClick={this.handleClick.bind(this)}>foo</a>
+React.createClass({
+    render: function () {
+        var self = this;
+        return <a onClick={function (e) {
+            self.handleClick(e);
+        }}>foo</a>
+    }
+});
 ```
 
 ### Owner vs. Parent Context
 
 react-server uses parent context which is slightly different to React 0.13's 
 owner context. React plans on switching to parent context in version 0.14, but
-react-server chose parent context due to its simpler implementation.
+react-server chose parent context due to its simpler implementation. In most
+cases, this is actually more reliable than the old owner context.
 
 ## Missing Utilities
 

--- a/lib/ReactComponentFactory.js
+++ b/lib/ReactComponentFactory.js
@@ -36,6 +36,15 @@ export function instantiateReactComponent(element, parentCompositeType) {
     }
 
     if (typeof element === 'object') {
+
+        if ("production" !== process.env.NODE_ENV) {
+            ("production" !== process.env.NODE_ENV ? warning(
+                element && (typeof element.type === 'function' ||
+                typeof element.type === 'string'),
+                'Only functions or strings can be mounted as React components.'
+            ) : null);
+        }
+
         // Special case string values
         if (parentCompositeType === element.type &&
             typeof element.type === 'string') {
@@ -54,6 +63,24 @@ export function instantiateReactComponent(element, parentCompositeType) {
             'Encountered invalid React node of type %s',
             typeof element
         ) : invariant(false));
+    }
+
+    if ("production" !== process.env.NODE_ENV) {
+        ("production" !== process.env.NODE_ENV ? warning(
+            typeof instance.construct === 'function' &&
+            typeof instance.mountComponent === 'function' &&
+            typeof instance.receiveComponent === 'function' &&
+            typeof instance.unmountComponent === 'function',
+            'Only React Components can be mounted.'
+        ) : null);
+    }
+
+    // Internal instances should fully constructed at this point, so they should
+    // not get any new fields added to them at this point.
+    if ("production" !== process.env.NODE_ENV) {
+        if (Object.preventExtensions) {
+            Object.preventExtensions(instance);
+        }
     }
 
     return instance;

--- a/lib/ReactCompositeComponent.js
+++ b/lib/ReactCompositeComponent.js
@@ -7,6 +7,12 @@ import assign from 'object-assign';
 import ReactComponent from './ReactComponent';
 import ReactNativeComponent from 'react/lib/ReactNativeComponent';
 import {instantiateReactComponent} from './ReactComponentFactory';
+import ReactPropTypeLocations from 'react/lib/ReactPropTypeLocations';
+import ReactPropTypeLocationNames from 'react/lib/ReactPropTypeLocationNames';
+import ReactElement from 'react/lib/ReactElement';
+
+import invariant from 'react/lib/invariant';
+import warning from 'react/lib/warning';
 
 class ReactCompositeComponent extends ReactComponent {
     constructor(element) {
@@ -18,20 +24,184 @@ class ReactCompositeComponent extends ReactComponent {
             this.element
         );
         var instance = new Component(this.props, context);
+        this._validateComponentInstance(Component, instance);
 
         instance.componentWillMount && instance.componentWillMount();
 
         var renderedChild = instance.render();
+        this._validateRenderedChild(renderedChild);
 
         var instantiatedChild = instantiateReactComponent(renderedChild, this.type);
 
         var childContext = instance.getChildContext && instance.getChildContext();
+        if (childContext) {
+            this._validateChildContext(instance, childContext);
+        }
 
         if (childContext) {
             childContext = assign({}, context, childContext);
         }
 
         return instantiatedChild.mountComponent(rootNodeID, transaction, childContext || context);
+    }
+
+    getName() {
+        return this.type.displayName || this.type.name || null;
+    }
+
+    _validateComponentInstance(Component, instance) {
+        if ("production" !== process.env.NODE_ENV) {
+            // This will throw later in _renderValidatedComponent, but add an early
+            // warning now to help debugging
+            ("production" !== process.env.NODE_ENV ? warning(
+                instance.render != null,
+                '%s(...): No `render` method found on the returned component ' +
+                'instance: you may have forgotten to define `render` in your ' +
+                'component or you may have accidentally tried to render an element ' +
+                'whose type is a function that isn\'t a React component.',
+                Component.displayName || Component.name || 'Component'
+            ) : null);
+            // Since plain JS classes are defined without any special initialization
+            // logic, we can not catch common errors early. Therefore, we have to
+            // catch them here, at initialization time, instead.
+            ("production" !== process.env.NODE_ENV ? warning(
+                !instance.getInitialState ||
+                instance.getInitialState.isReactClassApproved,
+                'getInitialState was defined on %s, a plain JavaScript class. ' +
+                'This is only supported for classes created using React.createClass. ' +
+                'Did you mean to define a state property instead?',
+                this.getName() || 'a component'
+            ) : null);
+            ("production" !== process.env.NODE_ENV ? warning(
+                !instance.getDefaultProps ||
+                instance.getDefaultProps.isReactClassApproved,
+                'getDefaultProps was defined on %s, a plain JavaScript class. ' +
+                'This is only supported for classes created using React.createClass. ' +
+                'Use a static property to define defaultProps instead.',
+                this.getName() || 'a component'
+            ) : null);
+            ("production" !== process.env.NODE_ENV ? warning(
+                !instance.propTypes,
+                'propTypes was defined as an instance property on %s. Use a static ' +
+                'property to define propTypes instead.',
+                this.getName() || 'a component'
+            ) : null);
+            ("production" !== process.env.NODE_ENV ? warning(
+                !instance.contextTypes,
+                'contextTypes was defined as an instance property on %s. Use a ' +
+                'static property to define contextTypes instead.',
+                this.getName() || 'a component'
+            ) : null);
+            ("production" !== process.env.NODE_ENV ? warning(
+                typeof instance.componentShouldUpdate !== 'function',
+                '%s has a method called ' +
+                'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' +
+                'The name is phrased as a question because the function is ' +
+                'expected to return a value.',
+                (this.getName() || 'A component')
+            ) : null);
+            ("production" !== process.env.NODE_ENV ? invariant(
+                typeof instance.state === 'object' && !Array.isArray(instance.state),
+                '%s.state: must be set to an object or null',
+                this.getName() || 'ReactCompositeComponent'
+            ) : invariant(typeof instance.state === 'object' && !Array.isArray(instance.state)));
+        }
+    }
+
+    _validateChildContext(instance, childContext) {
+        ("production" !== process.env.NODE_ENV ? invariant(
+            typeof instance.constructor.childContextTypes === 'object',
+            '%s.getChildContext(): childContextTypes must be defined in order to ' +
+            'use getChildContext().',
+            this.getName() || 'ReactCompositeComponent'
+        ) : invariant(typeof instance.constructor.childContextTypes === 'object'));
+        if ("production" !== process.env.NODE_ENV) {
+            this._validatePropTypes(
+                instance.constructor.childContextTypes,
+                childContext,
+                ReactPropTypeLocations.childContext
+            );
+        }
+        for (var name in childContext) {
+            ("production" !== process.env.NODE_ENV ? invariant(
+                name in instance.constructor.childContextTypes,
+                '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
+                this.getName() || 'ReactCompositeComponent',
+                name
+            ) : invariant(name in instance.constructor.childContextTypes));
+        }
+        return childContext;
+    }
+
+    /**
+     * Assert that the props are valid
+     *
+     * @param {object} propTypes Map of prop name to a ReactPropType
+     * @param {object} props
+     * @param {string} location e.g. "prop", "context", "child context"
+     * @private
+     */
+    _validatePropTypes(propTypes, props, location) {
+        // TODO: Stop validating prop types here and only use the element
+        // validation.
+        var componentName = this.getName();
+        for (var propName in propTypes) {
+            if (propTypes.hasOwnProperty(propName)) {
+                var error;
+                try {
+                    // This is intentionally an invariant that gets caught. It's the same
+                    // behavior as without this statement except with a better message.
+                    ("production" !== process.env.NODE_ENV ? invariant(
+                        typeof propTypes[propName] === 'function',
+                        '%s: %s type `%s` is invalid; it must be a function, usually ' +
+                        'from React.PropTypes.',
+                        componentName || 'React class',
+                        ReactPropTypeLocationNames[location],
+                        propName
+                    ) : invariant(typeof propTypes[propName] === 'function'));
+                    error = propTypes[propName](props, propName, componentName, location);
+                } catch (ex) {
+                    error = ex;
+                }
+                if (error instanceof Error) {
+                    // We may want to extend this logic for similar errors in
+                    // React.render calls, so I'm abstracting it away into
+                    // a function to minimize refactoring in the future
+                    var name = this.getName();
+                    var addendum = name ? ' Check the render method of `' + name + '`.' : '';
+
+                    if (location === ReactPropTypeLocations.prop) {
+                        // Preface gives us something to blacklist in warning module
+                        ("production" !== process.env.NODE_ENV ? warning(
+                            false,
+                            'Failed Composite propType: %s%s',
+                            error.message,
+                            addendum
+                        ) : null);
+                    } else {
+                        ("production" !== process.env.NODE_ENV ? warning(
+                            false,
+                            'Failed Context Types: %s%s',
+                            error.message,
+                            addendum
+                        ) : null);
+                    }
+                }
+            }
+        }
+    }
+
+    _validateRenderedChild(renderedChild) {
+        ("production" !== process.env.NODE_ENV ? invariant(
+            // TODO: An `isValidNode` function would probably be more appropriate
+            renderedChild === null || renderedChild === false ||
+            ReactElement.isValidElement(renderedChild),
+            '%s.render(): A valid ReactComponent must be returned. You may have ' +
+            'returned undefined, an array or some other invalid object.',
+            this.getName() || 'ReactCompositeComponent'
+        ) : invariant(// TODO: An `isValidNode` function would probably be more appropriate
+            renderedChild === null || renderedChild === false ||
+            ReactElement.isValidElement(renderedChild)));
     }
 }
 

--- a/lib/ReactDomComponent.js
+++ b/lib/ReactDomComponent.js
@@ -8,17 +8,73 @@ import assign from 'object-assign';
 import traverseAllChildren from 'react/lib/traverseAllChildren';
 import {instantiateReactComponent} from './ReactComponentFactory';
 
+var invariant = require("react/lib/invariant");
+var warning = require("react/lib/warning");
+
+var validatedTagCache = {};
+var VALID_TAG_REGEX = /^[a-zA-Z][a-zA-Z:_\.\-\d]*$/; // Simplified subset
+var hasOwnProperty = {}.hasOwnProperty;
+function validateDangerousTag(tag) {
+    if (!hasOwnProperty.call(validatedTagCache, tag)) {
+        ("production" !== process.env.NODE_ENV ? invariant(VALID_TAG_REGEX.test(tag), 'Invalid tag: %s', tag) : invariant(VALID_TAG_REGEX.test(tag)));
+        validatedTagCache[tag] = true;
+    }
+}
+
 class ReactDomComponent extends ReactComponent {
     constructor(element) {
         super(element);
+        validateDangerousTag(this.type);
     }
 
     mountComponent(rootNodeId, transaction, context) {
+        this._validateProps(this.props);
         return (
             createOpenTagMarkup(this, rootNodeId, transaction, context) +
             createContentMarkup(this, rootNodeId, transaction, context) +
             createCloseTagMarkup(this, rootNodeId, transaction, context)
         );
+    }
+
+    _validateProps(props) {
+        if (!props) {
+            return;
+        }
+        // Note the use of `==` which checks for null or undefined.
+        if (props.dangerouslySetInnerHTML != null) {
+            ("production" !== process.env.NODE_ENV ? invariant(
+                props.children == null,
+                'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
+            ) : invariant(props.children == null));
+            ("production" !== process.env.NODE_ENV ? invariant(
+                typeof props.dangerouslySetInnerHTML === 'object' &&
+                '__html' in props.dangerouslySetInnerHTML,
+                '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
+                'Please visit https://fb.me/react-invariant-dangerously-set-inner-html ' +
+                'for more information.'
+            ) : invariant(typeof props.dangerouslySetInnerHTML === 'object' &&
+                '__html' in props.dangerouslySetInnerHTML));
+        }
+        if ("production" !== process.env.NODE_ENV) {
+            ("production" !== process.env.NODE_ENV ? warning(
+                props.innerHTML == null,
+                'Directly setting property `innerHTML` is not permitted. ' +
+                'For more information, lookup documentation on `dangerouslySetInnerHTML`.'
+            ) : null);
+            ("production" !== process.env.NODE_ENV ? warning(
+                !props.contentEditable || props.children == null,
+                'A component is `contentEditable` and contains `children` managed by ' +
+                'React. It is now your responsibility to guarantee that none of ' +
+                'those nodes are unexpectedly modified or duplicated. This is ' +
+                'probably not intentional.'
+            ) : null);
+        }
+        ("production" !== process.env.NODE_ENV ? invariant(
+            props.style == null || typeof props.style === 'object',
+            'The `style` prop expects a mapping from style properties to values, ' +
+            'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
+            'using JSX.'
+        ) : invariant(props.style == null || typeof props.style === 'object'));
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "bench": "NODE_ENV=production node tests/bench",
-    "build": "webpack --output-file react-server.js",
+    "build": "webpack --output-file react-server.js; NODE_ENV=development webpack --output-file react-server.dev.js",
     "build-min": "webpack -p --output-file react-server.min.js",
     "build-react": " webpack ./node_modules/react/addons.js --output-file=react.js",
     "lint": "eslint index.js lib/*.js tests/**/*.js",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "object-assign": "^2.0.0",
     "react": "^0.13.2"
   },
+  "optionalDependencies": {
+    "profiler": "^1.2.3"
+  },
   "devDependencies": {
     "babel": "^5.2.12",
     "babel-core": "^5.2.9",
@@ -32,7 +35,6 @@
     "fluxible-router": "^0.1.4",
     "mocha": "^2.2.4",
     "mockery": "^1.4.0",
-    "profiler": "^1.2.3",
     "react-router": "^0.13.3",
     "webpack": "^1.8.11"
   }

--- a/register.js
+++ b/register.js
@@ -4,8 +4,11 @@
  */
 'use strict';
 
-// Ensure the cache for react-server is populated
-require('./dist/react-server');
+var requirePath = 'production' === process.env.NODE_ENV ?
+    './dist/react-server' : './dist/react-server.dev.js';
 
-require.cache[require.resolve('react')] = require.cache[require.resolve('./dist/react-server')];
-require.cache[require.resolve('react/addons')] = require.cache[require.resolve('./dist/react-server')];
+// Ensure the cache for react-server is populated
+require(requirePath);
+
+require.cache[require.resolve('react')] = require.cache[require.resolve(requirePath)];
+require.cache[require.resolve('react/addons')] = require.cache[require.resolve(requirePath)];

--- a/tests/fixtures/apps/chat/components/ThreadListItem.jsx
+++ b/tests/fixtures/apps/chat/components/ThreadListItem.jsx
@@ -23,7 +23,7 @@ var ThreadListItem = React.createClass({
 
     propTypes: {
         thread: ReactPropTypes.object,
-        currentThreadID: ReactPropTypes.string
+        currentThreadID: ReactPropTypes.bool
     },
 
     render: function() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     },
     plugins: [
         new webpack.DefinePlugin({
-            'process.env.NODE_ENV': JSON.stringify('production')
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production')
         })
     ]
 };


### PR DESCRIPTION
If production, it will still be the same, but in development will still show all of the warnings. Also added note about how to avoid warnings when binding methods.
